### PR TITLE
Add WithStoreSingleFrames option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ go func(){
 }()
 g.Generate()
 ```
+
+If you desire to keep all frames (out0000.jpeg, ...) pass a path to `New`:
+
+
+```go
+g, err := thumbgen.New("video.mp4", 360, 100, "out.jpg", thumbgen.WithStoreSingleFrames("/tmp"))
+```

--- a/cmd/thumbgen/main.go
+++ b/cmd/thumbgen/main.go
@@ -14,6 +14,7 @@ func main() {
 	w := flag.Int("w", 0, "The width of the sprite.")
 	n := flag.Int("n", 0, "The number of thumbnails to generate.")
 	jpegQ := flag.Int("q", 0, "Quality of jpeg output (optional).")
+	fDir := flag.String("f", "", "Store single frames at <path> (optional).")
 	flag.Parse()
 	if *i == "" || *o == "" || *w == 0 || *n == 0 {
 		flag.Usage()
@@ -25,6 +26,9 @@ func main() {
 	var opts []thumbgen.Option
 	if jpegQ != nil {
 		opts = append(opts, thumbgen.WithJpegCompression(*jpegQ))
+	}
+	if fDir != nil {
+		opts = append(opts, thumbgen.WithStoreSingleFrames(*fDir))
 	}
 	opts = append(opts, thumbgen.WithProgressChan(&progress))
 


### PR DESCRIPTION
- Added `WithStoreSingleFrames` option
- Fixed a (potential) bug:

```
func (g *Gen) generateFrames() error {
	for i := 0; i < 100; i++ { // <-- Changed that 100 to g.ThumbNum
		err := g.exportFrameAt(int(g.duration/float64(g.thumbNum)) * i)
		if err != nil {
			return err
		}
		if g.progressChan != nil {
			*g.progressChan <- i
		}
	}
	return nil
}
```